### PR TITLE
✨ 🔥 feat: 제약조건에 따라 Cost Method 변경

### DIFF
--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Airport.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Airport.java
@@ -9,7 +9,6 @@ import java.util.Map;
 @Getter
 @Setter
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class Airport extends AbstractPersistable {
     // 공항 이름
     private String name;

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Flight.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Flight.java
@@ -8,9 +8,7 @@ import java.time.temporal.ChronoUnit;
 
 @Getter
 @Setter
-
 @AllArgsConstructor
-@RequiredArgsConstructor
 public class Flight extends AbstractPersistable {
     //비행편 T/N
     private String TailNumber;

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
@@ -26,6 +26,8 @@ public class Pairing extends AbstractPersistable {
     public static int restTime;
     public static int LayoverTime;
     public static int QuickTurnaroundTime;
+    public static int hotelTime = 18 * 60;
+    public static int hotelMinTime = 720;
 
     public static void setStaticTime(int briefingTime,
                         int debriefingTime,
@@ -146,7 +148,7 @@ public class Pairing extends AbstractPersistable {
         int cost = 0;
         for (int i = 0; i < pair.size() - 1; i++) {
             // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
-            if (checkBreakTime(i) < 0) {
+            if (checkBreakTime(i) <= 0) {
                 return 0;
             }
 
@@ -171,7 +173,7 @@ public class Pairing extends AbstractPersistable {
         int cost = 0;
         for (int i = 0; i < pair.size() - 1; i++) {
             // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
-            if (checkBreakTime(i) < 0) {
+            if (checkBreakTime(i) <= 0) {
                 return 0;
             }
 
@@ -197,14 +199,16 @@ public class Pairing extends AbstractPersistable {
         int cost = 0;
         for (int i = 0; i < pair.size() - 1; i++) {
             // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
-            if (checkBreakTime(i) < 0) {
+            if (checkBreakTime(i) <= 0) {
                 return 0;
             }
 
+            int flightGap = checkBreakTime(i);
             // 음수가 아니라면 유효한 페어링이므로 HotelCost 계산
-            if (checkBreakTime(i) >= LayoverTime) {
-                cost += pair.get(i + 1).getOriginAirport().getHotelCost()
-                        * pair.get(0).getAircraft().getCrewNum();
+            if (flightGap >= hotelMinTime) {
+                cost += (pair.get(i + 1).getOriginAirport().getHotelCost()
+                        * pair.get(0).getAircraft().getCrewNum()
+                        * (int) (1 + (int) Math.floor(((float) flightGap - (float) hotelMinTime) / (float) hotelTime)));
             }
         }
 

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
@@ -12,9 +12,7 @@ import java.util.Map;
 
 @Getter
 @Setter
-
 @AllArgsConstructor
-@RequiredArgsConstructor
 @PlanningEntity
 public class Pairing extends AbstractPersistable {
     //변수로서 작동 된다. Pair 는 Flight 들의 연속이므로 ListVariable 로 작동된다.

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
@@ -12,18 +12,20 @@ import java.util.Map;
 
 @Getter
 @Setter
+
 @AllArgsConstructor
+@RequiredArgsConstructor
 @PlanningEntity
 public class Pairing extends AbstractPersistable {
     //변수로서 작동 된다. Pair 는 Flight 들의 연속이므로 ListVariable 로 작동된다.
     @PlanningListVariable(valueRangeProviderRefs = {"pairing"})
     private List<Flight> pair = new ArrayList<>();
     private Integer totalCost;
-    private static int briefingTime;
-    private static int debriefingTime;
-    private static int restTime;
-    private static int LayoverTime;
-    private static int QuickTurnaroundTime;
+    public static int briefingTime;
+    public static int debriefingTime;
+    public static int restTime;
+    public static int LayoverTime;
+    public static int QuickTurnaroundTime;
 
     public static void setStaticTime(int briefingTime,
                         int debriefingTime,
@@ -71,11 +73,6 @@ public class Pairing extends AbstractPersistable {
         return false;
     }
 
-    public int checkBreakTime(int index){
-        long breakTime = ChronoUnit.MINUTES.between(pair.get(index).getDestTime(), pair.get(index+1).getOriginTime());
-
-        return (int) Math.max(0,breakTime);
-    }
     /*
     public boolean minBreakTime(){
         for(int i=0; i<pair.size()-1; i++){
@@ -91,13 +88,6 @@ public class Pairing extends AbstractPersistable {
             if(checkBreakTime(i) <= 180) satisScore += 1000 * (180-checkBreakTime(i));
         }
         return satisScore;
-    }
-    public Integer getLayoverCost(){
-        int layoverCost = 0;
-        for(int i=0; i<pair.size()-1; i++){
-            if(checkBreakTime(i) >= 360) layoverCost += checkBreakTime(i) * pair.get(0).getAircraft().getLayoverCost()/100;
-        }
-        return layoverCost;
     }
 
     public void getlawImpossible(){
@@ -141,23 +131,91 @@ public class Pairing extends AbstractPersistable {
         String dest = pair.get(pair.size() - 1).getDestAirport().getName();
         String origin = pair.get(0).getOriginAirport().getName();
 
-        return deadheads.getOrDefault(origin, 0) * 100;
+        return deadheads.getOrDefault(origin, 0) / 2;
     }
-    /*
+
+    /**
+     * 페어링의 총 LayoverCost 반환
+     * 비행편간 간격이 LayoverTime 보다 크거나 같은 경우에만 LayoverCost 발생
+     * @return sum(LayoverCost) / 100
+     */
     public Integer getLayoverCost(){
-        if(pair.size() == 0) return 0;
+        // 페어링의 총 길이가 1개 이하라면 LayoverCost 없음
+        if(pair.size() <= 1) return 0;
 
-        long flightTime = 0;
-        long totalFlight = ChronoUnit.MINUTES.between(pair.get(0).getOriginTime(), pair.get(pair.size()-1).getDestTime());
+        int cost = 0;
+        for (int i = 0; i < pair.size() - 1; i++) {
+            // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
+            if (checkBreakTime(i) < 0) {
+                return 0;
+            }
 
-        for(Flight flight : pair){
-            flightTime += ChronoUnit.MINUTES.between(flight.getOriginTime(), flight.getDestTime());
+            // 음수가 아니라면 유효한 페어링이므로 LayoverCost 계산
+            if (checkBreakTime(i) >= LayoverTime) {
+                cost += (checkBreakTime(i) - LayoverTime) * pair.get(0).getAircraft().getLayoverCost();
+            }
         }
-        //(총 페어링 시간)이 (비행 시간의 합)보다 작으면 유효하지 않은 해로 간주함(이 경우 하드 조건에서 배제됨);
-        if(totalFlight<flightTime) return 0;
-        return (int) (totalFlight-flightTime)*pair.get(0).getAircraft().getLayoverCost() / 600;
+
+        return cost / 100;
     }
-    */
+
+    /**
+     * 페어링의 총 QuickTurnCost 반환
+     * 비행편간 간격이 QuickTurnaroundTime 보다 작은 경우에만 QuickTurnCost 발생
+     * @return sum(QuickTurnCost) / 100
+     */
+    public Integer getQuickTurnCost() {
+        // 페어링의 총 길이가 1개 이하라면 QuickTurnCost 없음
+        if(pair.size() <= 1) return 0;
+
+        int cost = 0;
+        for (int i = 0; i < pair.size() - 1; i++) {
+            // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
+            if (checkBreakTime(i) < 0) {
+                return 0;
+            }
+
+            // 음수가 아니라면 유효한 페어링이므로 QuickTurnCost 계산
+            if (checkBreakTime(i) < QuickTurnaroundTime) {
+                cost += (QuickTurnaroundTime - checkBreakTime(i)) * pair.get(0).getAircraft().getQuickTurnCost();
+            }
+        }
+
+        return cost / 100;
+    }
+
+    /**
+     * 페어링의 총 HotelCost 반환
+     * 총 인원수를 곱하는 이유 : Flight Cost, Layover Cost, QuickTurn Cost 모두 총 인원에 대한 값으로 계산된 후 입력받음
+     * 이걸 굳이 나눠야 싶음(레이오버가 생기면 호텔비용이 생기므로 합쳐도 되지 않을까 싶음)
+     * @return HotelCost(Layover가 발생했을 때 [해당 항공기의 인원 수 * 공항의 호텔 비용]를 다 더함) / 10
+     */
+    public Integer getHotelCost() {
+        // 페어링의 총 길이가 1개 이하라면 LayoverCost 없음
+        if(pair.size() <= 1) return 0;
+
+        int cost = 0;
+        for (int i = 0; i < pair.size() - 1; i++) {
+            // 만약 비행편 간격이 하나라도 음수라면 유효한 페어링이 아님
+            if (checkBreakTime(i) < 0) {
+                return 0;
+            }
+
+            // 음수가 아니라면 유효한 페어링이므로 HotelCost 계산
+            if (checkBreakTime(i) >= LayoverTime) {
+                cost += pair.get(i + 1).getOriginAirport().getHotelCost()
+                        * pair.get(0).getAircraft().getCrewNum();
+            }
+        }
+
+        return cost / 100;
+    }
+
+    private int checkBreakTime(int index){
+        long breakTime = ChronoUnit.MINUTES.between(pair.get(index).getDestTime(), pair.get(index+1).getOriginTime());
+
+        return (int) Math.max(0,breakTime);
+    }
     @Override
     public String toString() {
         return "Pairing - " + id +

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/PairingSolution.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/PairingSolution.java
@@ -12,8 +12,7 @@ import org.optaplanner.core.api.score.buildin.hardsoftlong.HardSoftLongScore;
 import java.util.List;
 
 @Getter
-@Setter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @PlanningSolution
 public class PairingSolution extends AbstractPersistable {
     //Aircraft 에 대한 모든 정보

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/PairingSolution.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/PairingSolution.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Getter
 @Setter
 @AllArgsConstructor
-@RequiredArgsConstructor
 @PlanningSolution
 public class PairingSolution extends AbstractPersistable {
     //Aircraft 에 대한 모든 정보

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/persistence/FlightCrewPairingXlsxFileIO.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/persistence/FlightCrewPairingXlsxFileIO.java
@@ -59,11 +59,10 @@ public class FlightCrewPairingXlsxFileIO extends AbstractXlsxSolutionFileIO<Pair
 
         @Override
         public PairingSolution read() {
-            readExchangeRate();
             readTimeData();
-            readAircraft();
-            readAirport();
-            readDeadhead();
+            readAircraft();         // 수정
+            readAirport();          // 수정
+            readDeadhead();         // 수정
             readFlight();
             return PairingSolution.builder()
                     .aircraftList(aircraftList)
@@ -115,9 +114,9 @@ public class FlightCrewPairingXlsxFileIO extends AbstractXlsxSolutionFileIO<Pair
                             .id(indexCnt++)
                             .type(row.getCell(0).getStringCellValue())
                             .crewNum((int) row.getCell(1).getNumericCellValue())
-                            .flightCost((int) row.getCell(2).getNumericCellValue() / exchangeRate)
-                            .layoverCost((int) row.getCell(3).getNumericCellValue() / exchangeRate)
-                            .quickTurnCost((int) row.getCell(4).getNumericCellValue() / exchangeRate).build());
+                            .flightCost((int) row.getCell(2).getNumericCellValue())
+                            .layoverCost((int) row.getCell(3).getNumericCellValue())
+                            .quickTurnCost((int) row.getCell(4).getNumericCellValue()).build());
                 } catch (IllegalStateException e) {
                     log.info("Finish Read Aircraft File");
                     break;
@@ -148,7 +147,7 @@ public class FlightCrewPairingXlsxFileIO extends AbstractXlsxSolutionFileIO<Pair
                     airportMap.put(row.getCell(0).getStringCellValue(), Airport.builder()
                             .id(indexCnt++)
                             .name(row.getCell(0).getStringCellValue())
-                            .hotelCost((int) row.getCell(1).getNumericCellValue() / exchangeRate)
+                            .hotelCost((int) row.getCell(1).getNumericCellValue())
                             .deadheadCost(new HashMap<>()).build());
                 } catch (IllegalStateException e) {
                     log.info("Finish Read Airport File");
@@ -180,7 +179,7 @@ public class FlightCrewPairingXlsxFileIO extends AbstractXlsxSolutionFileIO<Pair
 
                     airportMap.get(origin)
                             .putDeadhead(row.getCell(1).getStringCellValue(),
-                                    (int) row.getCell(2).getNumericCellValue() / exchangeRate);
+                                    (int) row.getCell(2).getNumericCellValue());
                 } catch (IllegalStateException e) {
                     log.info("Finish Read DeadHead File");
                     break;

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/score/ParingConstraintProvider.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/score/ParingConstraintProvider.java
@@ -21,6 +21,8 @@ public class ParingConstraintProvider implements ConstraintProvider {
 //                pairMinLength(constraintFactory),
                 baseDiff(constraintFactory),
                 layoverCost(constraintFactory),
+                quickTurnCost(constraintFactory),
+                hotelCost(constraintFactory),
                 satisCost(constraintFactory)
         };
     }
@@ -82,8 +84,7 @@ public class ParingConstraintProvider implements ConstraintProvider {
 //                .asConstraint("Min Length");
 //    }
 
-    // base 같아야 함 (soft) == Deadhead
-    // 좌석간 점유율 생각
+    //base 같아야 함 (soft) == Deadhead
     private Constraint baseDiff(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Pairing.class)
                 .filter(pairing -> (pairing.getPair().size() >= 1 && pairing.equalBase()))
@@ -96,6 +97,20 @@ public class ParingConstraintProvider implements ConstraintProvider {
                 .filter(pairing -> (pairing.getPair().size() >= 2))
                 .penalize(HardSoftLongScore.ONE_SOFT, Pairing::getLayoverCost)
                 .asConstraint("Layover Cost");
+    }
+
+    private Constraint quickTurnCost(ConstraintFactory constraintFactory) {
+        return constraintFactory.forEach(Pairing.class)
+                .filter(pairing -> (pairing.getPair().size() >= 2))
+                .penalize(HardSoftLongScore.ONE_SOFT, Pairing::getQuickTurnCost)
+                .asConstraint("QuickTurn Cost");
+    }
+
+    private Constraint hotelCost(ConstraintFactory constraintFactory) {
+        return constraintFactory.forEach(Pairing.class)
+                .filter(pairing -> (pairing.getPair().size() >= 2))
+                .penalize(HardSoftLongScore.ONE_SOFT, Pairing::getHotelCost)
+                .asConstraint("Hotel Cost");
     }
 
     private Constraint satisCost(ConstraintFactory constraintFactory) {

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/score/ParingConstraintProvider.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/score/ParingConstraintProvider.java
@@ -82,7 +82,8 @@ public class ParingConstraintProvider implements ConstraintProvider {
 //                .asConstraint("Min Length");
 //    }
 
-    //base 같아야 함 (soft) == Deadhead
+    // base 같아야 함 (soft) == Deadhead
+    // 좌석간 점유율 생각
     private Constraint baseDiff(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(Pairing.class)
                 .filter(pairing -> (pairing.getPair().size() >= 1 && pairing.equalBase()))


### PR DESCRIPTION
close #25
- Deadhead Cost 변경사항 없음

- Layover Cost
```java
    /**
     * 페어링의 총 LayoverCost 반환
     * 비행편간 간격이 LayoverTime 보다 크거나 같은 경우에만 LayoverCost 발생
     * @return sum(LayoverCost) / 100
     */
```

- QuickTurn Cost
```java
    /**
     * 페어링의 총 QuickTurnCost 반환
     * 비행편간 간격이 QuickTurnaroundTime 보다 작은 경우에만 QuickTurnCost 발생
     * @return sum(QuickTurnCost) / 100
     */
```

- Hotel Cost
```java
    /**
     * 페어링의 총 HotelCost 반환
     * 총 인원수를 곱하는 이유 : Flight Cost, Layover Cost, QuickTurn Cost 모두 총 인원에 대한 값으로 계산된 후 입력받음
     * 하지만 Hotel Cost는 1명에 대한 비용만 입력받으므로, 곱해줘야 함
     * 이걸 굳이 나눠야 싶음(레이오버가 생기면 호텔비용이 생기므로 합쳐도 되지 않을까 싶음)
     * @return HotelCost(Layover가 발생했을 때 [해당 항공기의 인원 수 * 공항의 호텔 비용]를 다 더함) / 10
     */
```