### PR TITLE
🐛 fix: dummyFlight로 인해 발생하는 문제 수정

### DIFF
--- a/ReinforcementLearning/CrewPairingEnv.py
+++ b/ReinforcementLearning/CrewPairingEnv.py
@@ -169,32 +169,8 @@ class CrewPairingEnv(gym.Env):
     def calculateScore(self, pairing):
 
         calculator = ScoreCalculator(pairing)
-
-        pair_hard_score = 0
-        pair_soft_score = 0
-        # 비행일정의 선후관계 만족 여부 -> 어기는 경우 1000점씩 부여
-        pair_hard_score = calculator.airportPossible()
-        # 선행 비행 도착지와 후행 비행 출발지 동일 여부 -> 어기는 경우 1000점씩 부여
-        pair_hard_score = calculator.timePossible()
-        # 선행 비행 기종과 후행 비행 기종 동일 여부 -> 어기는 경우 1000점씩 부여
-        pair_hard_score = calculator.aircraftType()
-        # 비행 횟수 제약: 비행 횟수가 4회 이상일 시 -> 하드스코어 부여(총 비행횟수 * 100) 제외
-        pair_hard_score = calculator.landingTimes()
-        # 비행 일수 제약: 페어링 총 기간이 7일 이상일 시 -> 하드스코어 부여((총 길이-7) * 100) 제외
-        # pair_hard_score = calculator.pairLength()
-        pair_hard_score = calculator.continuityPossible()  # 왜 얘만 자바에 두개들어가있는지 모르겠음
-        # deadhead cost 계산(Base diff): 출발공항과 도착 공항이 다를 경우 소프트 점수 부여
-        pair_soft_score = calculator.baseDiff()
-        # 두 비행 사이 간격이 6시간 이상인 경우, 해당 시간만큼의 layover salary를 score를 추가해줌.
-        pair_soft_score = calculator.layoverCost()
-        # 총 이동근무 cost 계산(MovingWork cost):페어링 길이가 2 이상일 시 - > 소프트스코어 부여(MovingWork cost 발생 시 cost+)
-        pair_soft_score = calculator.movingWorkCost()
-        # 선행 비행 도착시간과 후행 비행 출발시간의 차이가 1시간 이상인지 여부 -> 어기는 경우 100점씩 부여
-        pair_soft_score = calculator.quickTurnCost()
-        # 총 호텔숙박비 cost 계산(Hotel cost): 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(Hotel cost 발생 시 cost+)
-        pair_soft_score = calculator.hotelCost()
-        # 두 비행 사이 간격이 3시간 이하인 경우, 만족도 하락 -> min(0,(180-휴식 시간)*1000) 의 합을 score에 추가해줌. -> 이게 무슨 의미인지 잘 모르겠음.
-        pair_soft_score = calculator.satisCost()
+        pair_hard_score,pair_soft_score=calculator.calculateScore
+       
 
         return pair_hard_score, pair_soft_score
 

--- a/ReinforcementLearning/Pairing.py
+++ b/ReinforcementLearning/Pairing.py
@@ -118,7 +118,7 @@ class Pairing:
         for i in range(len(self.pair)):
             if self.pair[i].id == -1:  # dummyFlihgt 고려.
                 break
-            dest = self.pair[i].name
+            dest = self.pair[i].destAirport.name
         return self.pair[0].originAirport.name != dest
 
     def getSatisCost(self):
@@ -164,7 +164,7 @@ class Pairing:
             presentCrewNum = flight.aircraft.crewNum
 
             movingWorkCost += ((self.__getMaxCrewNum() - presentCrewNum)
-                               * flight.originAirport().getDeadheadCost(flight.destAirport))
+                               * flight.originAirport.getDeadheadCost(flight.destAirport))
 
         return movingWorkCost
 
@@ -237,9 +237,9 @@ class Pairing:
             if self.__checkBreakTime(i) < self.QuickTurnaroundTime:
                 cost += self.pair[i].aircraft.quickTurnCost
 
-        return cost // 100 ################################### 요기까지 수정함
+        return cost // 100 
 
-    def get_hotel_cost(self):
+    def getHotelCost(self): # !!!!!!!!!!!!!!!!!!추가적인 수정 필요
         """
             /**
             * 페어링의 총 HotelCost 반환
@@ -248,12 +248,9 @@ class Pairing:
             * @return sum(hotel cost) / 100
             */
         """
-        # 페어링의 총 길이가 1개 이하라면 HotelCost 없음
-        if len(self.pair) <= 1:
-            return 0
-
         cost = 0
         for i in range(len(self.pair) - 1):
+
             # 만약 비행편 간격이 하나라도 0이라면 유효한 페어링이 아님
             flight_gap = self.pair(i)
             if flight_gap == 0:

--- a/ReinforcementLearning/Pairing.py
+++ b/ReinforcementLearning/Pairing.py
@@ -51,7 +51,7 @@ class Pairing:
         """
 
         for i in range(len(self.pair) - 1):
-            if self.pair[i].destTime > self.pair[i + 1].originTime:
+            if self.pair[i].destTime > self.pair[i + 1].originTime and self.pair[i+1].id != -1: # 단, 이후 비행기가 dummyFlight면 무효
                 return True
         return False
 
@@ -64,7 +64,7 @@ class Pairing:
             */
         """
         for i in range(len(self.pair) - 1):
-            if self.pair[i].destAirport.name != self.pair[i + 1].originAirport.name:
+            if self.pair[i].destAirport.name != self.pair[i + 1].originAirport.name and self.pair[i+1].id != -1: # 이후 비행기가 dummyFlight면 무효
                 return True
         return False
     
@@ -114,7 +114,12 @@ class Pairing:
             * @return boolean
             */
         """
-        return self.pair[0].originAirport != self.pair[-1].destAirport
+        dest = None
+        for i in range(len(self.pair)):
+            if self.pair[i].id == -1:  # dummyFlihgt 고려.
+                break
+            dest = self.pair[i].name
+        return self.pair[0].originAirport.name != dest
 
     def getSatisCost(self):
         """
@@ -153,6 +158,9 @@ class Pairing:
         movingWorkCost = 0
 
         for flight in self.pair:
+            if flight.id==-1: #dummyFlight 만날 시 break
+                break
+
             presentCrewNum = flight.aircraft.crewNum
 
             movingWorkCost += ((self.__getMaxCrewNum() - presentCrewNum)
@@ -168,7 +176,7 @@ class Pairing:
             * @return deadhead cost / 2
             */
         """
-        if self.pair[0].id == -1:
+        if self.pair[0].id == -1:  # 빈 페어링의 경우 0 반환. 만약 페어링이 비어있더라도 equalBase()가 True 나오므로 필요.
             return 0
         else:
             dest = None
@@ -176,11 +184,10 @@ class Pairing:
             for i in range(len(self.pair)):
                 if self.pair[i].id != -1:
                     dest = self.pair[i].destAirport
-            if dest is not None:
-                # 출발공항에 대하여, 도착 공항이 어디인지를 인자로 넘겨주어, 해당하는 deadhead cost를 불러옴.
-                deadhead = origin.getDeadheadCost(dest)
+            # 출발공항에 대하여, 도착 공항이 어디인지를 인자로 넘겨주어, 해당하는 deadhead cost를 불러옴.
+            deadhead = origin.getDeadheadCost(dest)
 
-            return deadhead * self.__getMaxCrewNum()
+        return deadhead * self.__getMaxCrewNum()
 
     def getLayoverCost(self):
         """
@@ -189,10 +196,7 @@ class Pairing:
             * 비행편간 간격이 LayoverTime 보다 크거나 같은 경우에만 LayoverCost 발생
             * @return sum(LayoverCost) / 100
             */
-        """
-        if len(self.pair) <= 1:
-            return 0
-        
+        """        
         maxLayoverCost = self.pair[0].aircraft.layoverCost
         ## pair에 있는 flight 중 최대 maxLayoverCost를 찾음
         for flight in self.pair:
@@ -200,7 +204,7 @@ class Pairing:
 
         cost = 0
         for i in range(len(self.pair) - 1):
-            if self.__checkBreakTime(i) <= 0:
+            if self.__checkBreakTime(i) <= 0 and self.pair[i].id!=-1: # 단순 dummyFlight라서 return 0이 되는 경우 없게 만듦.
                 return 0
 
             ## if (getFlightGap(i) >= LayoverTime) {
@@ -221,22 +225,19 @@ class Pairing:
             * @return sum(QuickTurnCost) / 100
             */
         """
-        if len(self.pair) <= 1:
-            return 0
-        
         cost = 0
         for i in range(len(self.pair) - 1):
-            if self.__checkBreakTime(i) <= 0:
+            if self.__checkBreakTime(i) <= 0 and self.pair[i].id!=-1: # 단순히 dummyFlight여서 return 0 되는 것 방지
                 return 0
             
-            if self.pair[i].aircraft.type != self.pair[i+1].aircraft.type:
+            if self.pair[i].aircraft.type != self.pair[i+1].aircraft.type: #이게 멀까... cost+=0...?  09.20 동겸 작성
                 cost += 0
                 continue
 
             if self.__checkBreakTime(i) < self.QuickTurnaroundTime:
-                cost += self.pair[i].aircraft.getQuickTurnCost()
+                cost += self.pair[i].aircraft.quickTurnCost
 
-        return cost // 100
+        return cost // 100 ################################### 요기까지 수정함
 
     def get_hotel_cost(self):
         """
@@ -279,6 +280,9 @@ class Pairing:
             * @return (int) Math.max(0,breakTime)
             */
         """
+        if self.pair[index].id == -1 or self.pair[index+1].id == -1:  # dummy flight인 경우 고려
+            return 0
+
         breakTime = (self.pair[index+1].originTime -
                      self.pair[index].destTime).total_seconds() // 60
         return max(0, breakTime)

--- a/ReinforcementLearning/Scorecalculator.py
+++ b/ReinforcementLearning/Scorecalculator.py
@@ -15,7 +15,7 @@ class ScoreCalculator:
     
     def countFlight(self):  # dummyFlight를 제외한 pairing에 포함된 flight 수를 반환
         cnt = 0
-        for i in range(len(self.pairing)):
+        for i in range(len(self.pairing.pair)):
             if self.pairing.pair[i].id == -1:
                 break
             cnt = cnt+1
@@ -43,7 +43,7 @@ class ScoreCalculator:
     # 연속 근무, 연속 휴식에 대한 법적 제약. 틀리다면 Hard 점수 1000 점 부여
     def continuityPossible(self):
         score = 0
-        if len(self.pairing.pair) >= 2 and self.pairing.getContinuityImpossible() == True:
+        if self.countFlight()>=2 and self.pairing.getContinuityImpossible() == True:
             score = score+1000
         return score
 
@@ -94,7 +94,7 @@ class ScoreCalculator:
     # 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(Hotel cost 발생 시 cost+)
     def hotelCost(self):
         score = 0
-        if len(self.pairing.pair) >= 2:
+        if self.countFlight() >= 2:
             score = score+self.pairing.getHotelCost()
         return score
 
@@ -105,6 +105,6 @@ class ScoreCalculator:
     # / 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(Satis cost 발생 시 cost+)
     def satisCost(self):
         score = 0
-        if len(self.pairing.pair) >= 2:
+        if self.countFlight() >= 2:
             score = score+self.pairing.getSatisCost()
         return score

--- a/ReinforcementLearning/Scorecalculator.py
+++ b/ReinforcementLearning/Scorecalculator.py
@@ -12,6 +12,14 @@ class ScoreCalculator:
         softScore = self.baseDiff()+self.layoverCost()+self.movingWorkCost(
         )+self.quickTurnCost()+self.hotelCost()+self.satisCost()
         return hardScore, softScore
+    
+    def countFlight(self):  # dummyFlight를 제외한 pairing에 포함된 flight 수를 반환
+        cnt = 0
+        for i in range(len(self.pairing)):
+            if self.pairing.pair[i].id == -1:
+                break
+            cnt = cnt+1
+        return cnt
 
     # Hard 조건
     # 시간적 선후관계 판단. 틀리다면 Hard score 1000점 부여
@@ -45,7 +53,8 @@ class ScoreCalculator:
     # 첫 출발공항과 마지막 도착공항이 다를 시 - > 소프트스코어 부여(항공편에 따른 가격)
     def baseDiff(self):
         score = 0
-        if len(self.pairing.pair) >= 1 and self.pairing.equalBase() == True:
+        if self.countFlight() >= 1 and self.pairing.equalBase() == True:
+
             score = score+self.pairing.getDeadheadCost()
         return score
 
@@ -55,7 +64,7 @@ class ScoreCalculator:
     # 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(layover 발생 시 cost+)
     def layoverCost(self):
         score = 0
-        if len(self.pairing.pair) >= 2:
+        if self.countFlight() >= 2:
             score = score+self.pairing.getLayoverCost()
         return score
 
@@ -65,7 +74,7 @@ class ScoreCalculator:
     # 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(MovingWork cost 발생 시 cost+)
     def movingWorkCost(self):
         score = 0
-        if len(self.pairing.pair) >= 2:
+        if self.countFlight() >= 2:
             score = score+self.pairing.getMovingWorkCost()
         return score
 
@@ -75,7 +84,7 @@ class ScoreCalculator:
     # 페어링 길이가 2 이상일 시 - > 소프트스코어 부여(QuickTurn cost 발생 시 cost+)
     def quickTurnCost(self):
         score = 0
-        if len(self.pairing.pair) >= 2:
+        if self.countFlight() >= 2:
             score = score+self.pairing.getQuickTurnCost()
         return score
 


### PR DESCRIPTION
강화학습에서 만들어진 Pairing Set에, 비어있는 flight에 대하여 dummyFlight를 넣기로 결정을 한 이후로, Score 계산 과정에서 이가 부분적으로만 반영되어 (hard, soft Score) 계산이 의도대로 되지 않는 문제가 존재했었음.

ScoreCalculator.py-> pairing에서 dummyFlight를 제외한 Flight의 개수를 세어주는 메소드 'countFlight()' 추가 및,
기존의 len(pairing.pair) 부분을 전부 countFlight()로 변경해줌.

Pairing.py-> dummyFlight가 존재할 수 있음을 고려하여, id가 -1인 flight가 score계산에 예상치 못한 영향을 주지 못하도록 수정.