### PR TITLE
✨ feat: modify hard and soft score for new constraints

### DIFF
--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
@@ -170,15 +170,19 @@ public class Pairing extends AbstractPersistable {
     }
 
     /**
-     * 페어링의 총 갈아 반환 (일)
+     * 페어링의 총 길아 반환 (일)
      * @return 마지막 비행 도착시간 - 처음 비행 시작시간
      */
     public Integer getActiveTimeCost() {
         if (pair.size() == 0) return 0;
 
-        return Math.max(0, 2* (int) ChronoUnit.DAYS.between(pair.get(0).getOriginTime(), pair.get(pair.size() - 1).getDestTime()));
+        return Math.max(0, (int) ChronoUnit.DAYS.between(pair.get(0).getOriginTime(), pair.get(pair.size() - 1).getDestTime()));
     }
 
+    /**
+     * 페어링이 4일을 넘는 지 반환 (Boolean)
+     * @return 4일을 넘으면 true, 아니면 false
+     */
     public Boolean isLenghtPossible(){
         if (pair.size() <= 1) return false;
 


### PR DESCRIPTION
* #100 
* 홈베이스 출발을 소프트 제약으로 변경 후, 홈베이스에서 출발하지 않으면 90점 부여
* 총 Manday 일당 소프트 2점 부여
* 데드헤드가 존재하는 페어링 당 8점 부여
* aircraftPossible(항공기종 확인) 삭제
* 페어링 최대 4일 제약과 Manday&Deadhead 외의 Soft Score 0점 부여 처리
