### PR TITLE
🐛 fix: consider active legs

### DIFF
--- a/PairingCreater/src/main/java/org/dongguk/common/business/SolutionBusiness.java
+++ b/PairingCreater/src/main/java/org/dongguk/common/business/SolutionBusiness.java
@@ -205,15 +205,26 @@ public final class SolutionBusiness<Solution_, Score_ extends Score<Score_>> imp
 
             // 최신 솔루션의 페어링 리스트를 가져와 로깅
             List<Pairing> pairingList = solution.getPairingList();
-            // writeLog(logFilePath, "Current Pairing List: " + pairingList.toString());
 
             // 데드헤드와 맨데이 구하기
             int deadheadCnt = 0;
             int mandayLen = 0;
+            int filteredFlightCount = 0;
+            int includedFlightCount = 0;
 
             for (Pairing pairing : pairingList) {
                 List<Flight> pair = pairing.getPair();
                 if (!pair.isEmpty()) {
+                    String originAirport = pair.get(0).getOriginAirport().getName();
+
+                    // HB1 또는 HB2에서 출발하지 않는 페어링 필터링
+                    if (!"HB1".equals(originAirport) && !"HB2".equals(originAirport)) {
+                        filteredFlightCount += pair.size();
+                        continue; // 필터링된 페어링은 계산에서 제외
+                    }
+
+                    includedFlightCount += pair.size(); // 포함된 비행 카운트 증가
+
                     if (pair.get(0).getOriginAirport() != pair.get(pair.size() - 1).getDestAirport()) {
                         deadheadCnt++; // #of deadheads
                     }
@@ -224,7 +235,7 @@ public final class SolutionBusiness<Solution_, Score_ extends Score<Score_>> imp
                 }
             }
 
-            writeLog(logFilePath, "Deadhead Count: " + deadheadCnt + "  Mandays: " + mandayLen);
+            writeLog(logFilePath, "Deadhead Count: " + deadheadCnt + "  Mandays: " + mandayLen + ", Active Legs: " + includedFlightCount + ", Excluded Legs: " + filteredFlightCount);
 
         }, 0, 240, TimeUnit.SECONDS);
     }

--- a/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
+++ b/PairingCreater/src/main/java/org/dongguk/crewpairing/domain/Pairing.java
@@ -197,7 +197,7 @@ public class Pairing extends AbstractPersistable {
     public Boolean isLenghtPossible(){
         if (pair.size() <= 1) return false;
 
-        if (ChronoUnit.DAYS.between(pair.get(0).getOriginTime(), pair.get(pair.size() - 1).getDestTime()) > 4)
+        if (ChronoUnit.DAYS.between(pair.get(0).getOriginTime(), pair.get(pair.size() - 1).getDestTime())+1 > 4)
             return true;
         else return false;
     }


### PR DESCRIPTION
close #105 
* ChronoUnit.DAYS.between은 날짜의 차이를 계산할 때 종료일을 포함하지 않는 방식으로 작동함. 따라서 첫날과 마지막 날을 포함한 전체 일수를 계산하려면 추가로 1을 더해줘야 함.
* 출력 형식 변경 : `00:00 - Deadhead Count: 7420  Mandays: 7633, Active Legs: 7633, Excluded Legs: 8023`
